### PR TITLE
Update 2023-09-27-papillon23a.md: Update authors' list to match newer…

### DIFF
--- a/_posts/2023-09-27-papillon23a.md
+++ b/_posts/2023-09-27-papillon23a.md
@@ -19,9 +19,7 @@ lastpage: 8
 page: 3-8
 order: 3
 cycles: false
-bibtex_author: Papillon, Mathilde and Hajij, Mustafa and Myers, Audun and Frantzen,
-  Florian and Jenne, Helen and Mathe, Johan and Hoppe, Josef
-  and Schaub, Michael and Papamarkou, Theodore and Guzm\'{a}n-S\'{a}enz, Aldo and Livesay, Neal and Dey, Tamal and Rabinowitz, Abraham and Brent,
+bibtex_author: Papillon, Mathilde and Hajij, Mustafa and Myers, Audun and and Jenne, Helen and Mathe, Johan and Papamarkou, Theodore and Guzm\'{a}n-S\'{a}enz, Aldo and Livesay, Neal and Dey, Tamal and Rabinowitz, Abraham and Brent,
   Aiden and Salatiello, Alessandro and Nikitin, Alexander and Zia, Ali and Battiloro,
   Claudio and Gavrilev, Dmitrii and Magai, German and Bazhenov,
   Gleb and Bernardez, Guillermo and Spinelli, Indro and Agerberg, Jens and Nadimpalli,
@@ -29,10 +27,9 @@ bibtex_author: Papillon, Mathilde and Hajij, Mustafa and Myers, Audun and Frantz
   and Yang, Maosheng and Hassanin, Mohammed and Gardaa, Odin Hoff and Zaghen, Olga
   and Hausner, Paul and Snopoff, Paul and Ballester, Rub\'{e}n and
   Barikbin, Sadrodin and Escalera, Sergio and Fiorellino, Simone and Kvinge, Henry
-  and Meissner, Jan and Ramamurthy, Karthikeyan Natesan and Scholkemper, Michael and
+  and Ramamurthy, Karthikeyan Natesan and
   Rosen, Paul and Walters, Robin and Samaga, Shreyas N. and Mukherjee, Soham and Sanborn,
-  Sophia and Emerson, Tegan and Doster, Timothy and Birdal, Tolga and Grande, Vincent
-  and Khamis, Abdelwahed and Scardapane, Simone and Singh, Suraj and Malygina, Tatiana
+  Sophia and Emerson, Tegan and Doster, Timothy and Birdal, Tolga and Khamis, Abdelwahed and Scardapane, Simone and Singh, Suraj and Malygina, Tatiana
   and Yue, Yixiao and Miolane, Nina
 author:
 - given: Mathilde
@@ -41,16 +38,10 @@ author:
   family: Hajij
 - given: Audun
   family: Myers
-- given: Florian
-  family: Frantzen
 - given: Helen
   family: Jenne
 - given: Johan
   family: Mathe
-- given: Josef
-  family: Hoppe
-- given: Michael
-  family: Schaub
 - given: Theodore
   family: Papamarkou
 - given: Aldo
@@ -115,12 +106,8 @@ author:
   family: Fiorellino
 - given: Henry
   family: Kvinge
-- given: Jan
-  family: Meissner
 - given: Karthikeyan Natesan
   family: Ramamurthy
-- given: Michael
-  family: Scholkemper
 - given: Paul
   family: Rosen
 - given: Robin
@@ -137,8 +124,6 @@ author:
   family: Doster
 - given: Tolga
   family: Birdal
-- given: Vincent
-  family: Grande
 - given: Abdelwahed
   family: Khamis
 - given: Simone


### PR DESCRIPTION
This PR follows PR #3 on updating papillon3a.pdf and PR #4 on updating the corresponding .md.

This PR fixes an error in PR #4, where some authors still appear in the .md file whereas they should have been removed following the update of the newer version of updating papillon3a.pdf in PR #3.